### PR TITLE
Migrate profile handlers

### DIFF
--- a/nsls2_detector_handlers/__init__.py
+++ b/nsls2_detector_handlers/__init__.py
@@ -1,4 +1,29 @@
-
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
+
+
+class HandlerBase:
+    """
+    Base-class for Handlers to provide the boiler plate to
+    make them usable in context managers by providing stubs of
+    ``__enter__``, ``__exit__`` and ``close``
+    """
+
+    specs = set()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
+        pass
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/nsls2_detector_handlers/srx_flyscans.py
+++ b/nsls2_detector_handlers/srx_flyscans.py
@@ -7,7 +7,11 @@ class ZebraHDF5Handler(HandlerBase):
     specs = {'ZEBRA_HDF51', 'SIS_HDF51'}
 
     def __init__(self, resource_fn):
+        self._resource_fn = resource_fn
         self._handle = h5py.File(resource_fn, 'r')
 
     def __call__(self, *, column):
         return self._handle[column][:]
+
+    def get_file_list(self, datum_kwarg_gen):
+        return [self._resource_fn]

--- a/nsls2_detector_handlers/srx_flyscans.py
+++ b/nsls2_detector_handlers/srx_flyscans.py
@@ -4,7 +4,7 @@ import h5py
 
 
 class ZebraHDF5Handler(HandlerBase):
-    HANDLER_NAME = 'ZEBRA_HDF51'
+    specs = {'ZEBRA_HDF51', 'SIS_HDF51'}
 
     def __init__(self, resource_fn):
         self._handle = h5py.File(resource_fn, 'r')

--- a/nsls2_detector_handlers/srx_flyscans.py
+++ b/nsls2_detector_handlers/srx_flyscans.py
@@ -1,0 +1,13 @@
+from . import HandlerBase
+
+import h5py
+
+
+class ZebraHDF5Handler(HandlerBase):
+    HANDLER_NAME = 'ZEBRA_HDF51'
+
+    def __init__(self, resource_fn):
+        self._handle = h5py.File(resource_fn, 'r')
+
+    def __call__(self, *, column):
+        return self._handle[column][:]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # List required packages in this file, one per line.
+h5py

--- a/setup.py
+++ b/setup.py
@@ -40,13 +40,13 @@ setup(
     description="Staging repo for handlers specific to NSLS-II",
     long_description=readme,
     author="Brookhaven National Laboratory",
-    author_email='',
+    author_email='dama@bnl.gov',
     url='https://github.com/bluesky/nsls2-detector-handlers',
     python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
     packages=find_packages(exclude=['docs', 'tests']),
     entry_points={
-        'console_scripts': [
-            # 'command = some.module:some_function',
+        'databroker.handlers': [
+            'ZEBRA_HDF51 = nsls2_detector_handlers.srx_flyscans:ZebraHDF5Handler',
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     entry_points={
         'databroker.handlers': [
             'ZEBRA_HDF51 = nsls2_detector_handlers.srx_flyscans:ZebraHDF5Handler',
+            'SIS_HDF51 = nsls2_detector_handlers.srx_flyscans:ZebraHDF5Handler',
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
Migrate databroker handlers from beamline profiles. 

Related: https://github.com/bluesky/databroker/issues/533

This repo is for handlers that don't fit into `area-detector-handlers` or `pizzabox-handlers`.