### PR TITLE
Add ISS handlers

### DIFF
--- a/nsls2_detector_handlers/electrometer.py
+++ b/nsls2_detector_handlers/electrometer.py
@@ -1,5 +1,6 @@
-import numpy as np
 import os
+
+import numpy as np
 import pandas as pd
 
 from . import HandlerBase

--- a/nsls2_detector_handlers/electrometer.py
+++ b/nsls2_detector_handlers/electrometer.py
@@ -1,0 +1,77 @@
+import numpy as np
+import os
+import pandas as pd
+
+from . import HandlerBase
+
+
+class ElectrometerBinFileHandler(HandlerBase):
+    """Read electrometer *.bin files"""
+
+    def __init__(self, fpath):
+        # It's a text config file, which we don't store in the resources yet, parsing for now
+        fpath_txt = f'{os.path.splitext(fpath)[0]}.txt'
+
+        with open(fpath_txt, 'r') as fp:
+            N = int(fp.readline().split(':')[1])
+            Gains = [int(x) for x in fp.readline().split(':')[1].split(',')]
+            Offsets = [int(x) for x in fp.readline().split(':')[1].split(',')]
+            FAdiv = float(fp.readline().split(':')[1])
+            fp.readline()
+            Ranges = [int(x) for x in fp.readline().split(':')[1].split(',')]
+            FArate = float(fp.readline().split(':')[1])
+            # trigger_timestamp = float(fp.readline().split(':')[1].strip().replace(',', '.'))
+
+            def Range(val):
+                ranges = {1: 1,
+                          2: 10,
+                          4: 100,
+                          8: 1000,
+                          16: 100087}
+                try:
+                    ret = ranges[val]
+                except:
+                    raise ValueError(f'The value "val" can be one of {ranges.keys()}')
+                return ret
+            # 1566332720 366808768 -4197857 11013120 00
+            raw_data = np.fromfile(fpath, dtype=np.int32)
+
+            A = []
+            B = []
+            C = []
+            D = []
+            T = []
+            Ra = Range(Ranges[0])
+            Rb = Range(Ranges[1])
+            Rc = Range(Ranges[2])
+            Rd = Range(Ranges[3])
+            # dt = 1.0 / FArate / 1000.0
+
+            num_columns = 6
+            raw_data = raw_data.reshape((raw_data.size // num_columns, num_columns))
+
+            derived_data = np.zeros((raw_data.shape[0], raw_data.shape[1] - 1))
+            derived_data[:, 0] = raw_data[:, -2] + raw_data[:, -1] * 8.0051232 * 1e-9  # Unix timestamp with nanoseconds
+            derived_data[:, 1] = Ra * ((raw_data[:, 0] / FAdiv) - Offsets[0]) / Gains[0]
+            derived_data[:, 2] = Rb * ((raw_data[:, 1] / FAdiv) - Offsets[1]) / Gains[1]
+            derived_data[:, 3] = Rc * ((raw_data[:, 2] / FAdiv) - Offsets[2]) / Gains[2]
+            derived_data[:, 4] = Rd * ((raw_data[:, 3] / FAdiv) - Offsets[3]) / Gains[3]
+
+            # for i in range(0, len(X), 4):
+            #     A.append(Ra * ((X[i + 0] / FAdiv) - Offsets[0]) / Gains[0])
+            #     B.append(Rb * ((X[i + 1] / FAdiv) - Offsets[1]) / Gains[1])
+            #     C.append(Rc * ((X[i + 2] / FAdiv) - Offsets[2]) / Gains[2])
+            #     D.append(Rd * ((X[i + 3] / FAdiv) - Offsets[3]) / Gains[3])
+            #     T.append(i * dt / 4.0)
+
+        # data = np.vstack((np.array(T) + trigger_timestamp,
+        #                   np.array(A),
+        #                   np.array(B),
+        #                   np.array(C),
+        #                   np.array(D))).T
+
+        self.df = pd.DataFrame(data=derived_data, columns=['timestamp', 'i0', 'it', 'ir', 'iff'])
+        self.raw_data = raw_data
+
+    def __call__(self):
+        return self.df, self.raw_data

--- a/nsls2_detector_handlers/electrometer.py
+++ b/nsls2_detector_handlers/electrometer.py
@@ -20,7 +20,6 @@ class ElectrometerBinFileHandler(HandlerBase):
             fp.readline()
             Ranges = [int(x) for x in fp.readline().split(':')[1].split(',')]
             FArate = float(fp.readline().split(':')[1])
-            # trigger_timestamp = float(fp.readline().split(':')[1].strip().replace(',', '.'))
 
             def Range(val):
                 ranges = {1: 1,
@@ -36,16 +35,10 @@ class ElectrometerBinFileHandler(HandlerBase):
             # 1566332720 366808768 -4197857 11013120 00
             raw_data = np.fromfile(fpath, dtype=np.int32)
 
-            A = []
-            B = []
-            C = []
-            D = []
-            T = []
             Ra = Range(Ranges[0])
             Rb = Range(Ranges[1])
             Rc = Range(Ranges[2])
             Rd = Range(Ranges[3])
-            # dt = 1.0 / FArate / 1000.0
 
             num_columns = 6
             raw_data = raw_data.reshape((raw_data.size // num_columns, num_columns))
@@ -56,19 +49,6 @@ class ElectrometerBinFileHandler(HandlerBase):
             derived_data[:, 2] = Rb * ((raw_data[:, 1] / FAdiv) - Offsets[1]) / Gains[1]
             derived_data[:, 3] = Rc * ((raw_data[:, 2] / FAdiv) - Offsets[2]) / Gains[2]
             derived_data[:, 4] = Rd * ((raw_data[:, 3] / FAdiv) - Offsets[3]) / Gains[3]
-
-            # for i in range(0, len(X), 4):
-            #     A.append(Ra * ((X[i + 0] / FAdiv) - Offsets[0]) / Gains[0])
-            #     B.append(Rb * ((X[i + 1] / FAdiv) - Offsets[1]) / Gains[1])
-            #     C.append(Rc * ((X[i + 2] / FAdiv) - Offsets[2]) / Gains[2])
-            #     D.append(Rd * ((X[i + 3] / FAdiv) - Offsets[3]) / Gains[3])
-            #     T.append(i * dt / 4.0)
-
-        # data = np.vstack((np.array(T) + trigger_timestamp,
-        #                   np.array(A),
-        #                   np.array(B),
-        #                   np.array(C),
-        #                   np.array(D))).T
 
         self.df = pd.DataFrame(data=derived_data, columns=['timestamp', 'i0', 'it', 'ir', 'iff'])
         self.raw_data = raw_data

--- a/nsls2_detector_handlers/electrometer.py
+++ b/nsls2_detector_handlers/electrometer.py
@@ -12,7 +12,7 @@ class ElectrometerBinFileHandler(HandlerBase):
     def __init__(self, fpath):
         # It's a text config file, which we don't store in the resources yet, parsing for now
         fpath_txt = f'{os.path.splitext(fpath)[0]}.txt'
-        self.filename = fpath
+        self.files = [fpath, fpath_txt]
 
         with open(fpath_txt, 'r') as fp:
             N = int(fp.readline().split(':')[1])
@@ -59,4 +59,4 @@ class ElectrometerBinFileHandler(HandlerBase):
         return self.df, self.raw_data
 
     def get_file_list(self, datum_kwargs_gen):
-        return [self.filename]
+        return self.files

--- a/nsls2_detector_handlers/electrometer.py
+++ b/nsls2_detector_handlers/electrometer.py
@@ -11,6 +11,7 @@ class ElectrometerBinFileHandler(HandlerBase):
     def __init__(self, fpath):
         # It's a text config file, which we don't store in the resources yet, parsing for now
         fpath_txt = f'{os.path.splitext(fpath)[0]}.txt'
+        self.filename = fpath
 
         with open(fpath_txt, 'r') as fp:
             N = int(fp.readline().split(':')[1])
@@ -55,3 +56,6 @@ class ElectrometerBinFileHandler(HandlerBase):
 
     def __call__(self):
         return self.df, self.raw_data
+
+    def get_file_list(self, datum_kwargs_gen):
+        return [self.filename]

--- a/nsls2_detector_handlers/pizzabox.py
+++ b/nsls2_detector_handlers/pizzabox.py
@@ -12,6 +12,7 @@ class PizzaBoxAnHandlerTxt(HandlerBase):
 
     def __init__(self, fpath, chunk_size):
         self.chunk_size = chunk_size
+        self.filename = fpath
         with open(fpath, 'r') as f:
             self.lines = list(f)
 
@@ -19,6 +20,9 @@ class PizzaBoxAnHandlerTxt(HandlerBase):
         cs = self.chunk_size
         return [self.encoder_row(*(int(v, base=b) for v, b in zip(ln.split(), self.bases)))
                 for ln in self.lines[chunk_num*cs:(chunk_num+1)*cs]]
+
+    def get_file_list(self, datum_kwargs_gen):
+        return [self.filename]
 
 
 class PizzaBoxDIHandlerTxt(HandlerBase):
@@ -28,6 +32,7 @@ class PizzaBoxDIHandlerTxt(HandlerBase):
 
     def __init__(self, fpath, chunk_size):
         self.chunk_size = chunk_size
+        self.filename = fpath
         with open(fpath, 'r') as f:
             self.lines = list(f)
 
@@ -35,6 +40,9 @@ class PizzaBoxDIHandlerTxt(HandlerBase):
         cs = self.chunk_size
         return [self.di_row(*(int(v) for v in ln.split()))
                 for ln in self.lines[chunk_num*cs:(chunk_num+1)*cs]]
+
+    def get_file_list(self, datum_kwargs_gen):
+        return [self.filename]
 
 
 class PizzaBoxEncHandlerTxt(HandlerBase):
@@ -45,6 +53,7 @@ class PizzaBoxEncHandlerTxt(HandlerBase):
 
     def __init__(self, fpath, chunk_size):
         self.chunk_size = chunk_size
+        self.filename = fpath
         with open(fpath, 'r') as f:
             self.lines = list(f)
 
@@ -53,6 +62,9 @@ class PizzaBoxEncHandlerTxt(HandlerBase):
         return [self.encoder_row(*(int(v) for v in ln.split()))
                 for ln in self.lines[chunk_num*cs:(chunk_num+1)*cs]]
 
+    def get_file_list(self, datum_kwargs_gen):
+        return [self.filename]
+
 
 # New handlers to support reading files into a Pandas dataframe
 class PizzaBoxAnHandlerTxtPD(HandlerBase):
@@ -60,9 +72,13 @@ class PizzaBoxAnHandlerTxtPD(HandlerBase):
 
     def __init__(self, fpath):
         self.df = pd.read_table(fpath, names=['ts_s', 'ts_ns', 'index', 'adc'], sep=' ')
+        self.filename = fpath
 
     def __call__(self):
         return self.df
+
+    def get_file_list(self, datum_kwargs_gen):
+        return [self.filename]
 
 
 class PizzaBoxDIHandlerTxtPD(HandlerBase):
@@ -70,9 +86,13 @@ class PizzaBoxDIHandlerTxtPD(HandlerBase):
 
     def __init__(self, fpath):
         self.df = pd.read_table(fpath, names=['ts_s', 'ts_ns', 'encoder', 'index', 'di'], sep=' ')
+        self.filename = fpath
 
     def __call__(self):
         return self.df
+
+    def get_file_list(self, datum_kwargs_gen):
+        return [self.filename]
 
 
 class PizzaBoxEncHandlerTxtPD(HandlerBase):
@@ -80,6 +100,10 @@ class PizzaBoxEncHandlerTxtPD(HandlerBase):
 
     def __init__(self, fpath):
         self.df = pd.read_table(fpath, names=['ts_s', 'ts_ns', 'encoder', 'index', 'state'], sep=' ')
+        self.filename = fpath
 
     def __call__(self):
         return self.df
+
+    def get_file_list(self, datum_kwargs_gen):
+        return [self.filename]

--- a/nsls2_detector_handlers/pizzabox.py
+++ b/nsls2_detector_handlers/pizzabox.py
@@ -1,0 +1,85 @@
+import pandas as pd
+
+from collections import namedtuple
+from . import HandlerBase
+
+
+class PizzaBoxAnHandlerTxt(HandlerBase):
+    """Read PizzaBox text files using info from filestore."""
+
+    encoder_row = namedtuple('encoder_row', ['ts_s', 'ts_ns', 'index', 'adc'])
+    bases = (10, 10, 10, 16)
+
+    def __init__(self, fpath, chunk_size):
+        self.chunk_size = chunk_size
+        with open(fpath, 'r') as f:
+            self.lines = list(f)
+
+    def __call__(self, chunk_num):
+        cs = self.chunk_size
+        return [self.encoder_row(*(int(v, base=b) for v, b in zip(ln.split(), self.bases)))
+                for ln in self.lines[chunk_num*cs:(chunk_num+1)*cs]]
+
+
+class PizzaBoxDIHandlerTxt(HandlerBase):
+    """Read PizzaBox text files using info from filestore."""
+
+    di_row = namedtuple('di_row', ['ts_s', 'ts_ns', 'encoder', 'index', 'di'])
+
+    def __init__(self, fpath, chunk_size):
+        self.chunk_size = chunk_size
+        with open(fpath, 'r') as f:
+            self.lines = list(f)
+
+    def __call__(self, chunk_num):
+        cs = self.chunk_size
+        return [self.di_row(*(int(v) for v in ln.split()))
+                for ln in self.lines[chunk_num*cs:(chunk_num+1)*cs]]
+
+
+class PizzaBoxEncHandlerTxt(HandlerBase):
+    """Read PizzaBox text files using info from filestore."""
+
+    encoder_row = namedtuple('encoder_row',
+                             ['ts_s', 'ts_ns', 'encoder', 'index', 'state'])
+
+    def __init__(self, fpath, chunk_size):
+        self.chunk_size = chunk_size
+        with open(fpath, 'r') as f:
+            self.lines = list(f)
+
+    def __call__(self, chunk_num):
+        cs = self.chunk_size
+        return [self.encoder_row(*(int(v) for v in ln.split()))
+                for ln in self.lines[chunk_num*cs:(chunk_num+1)*cs]]
+
+
+# New handlers to support reading files into a Pandas dataframe
+class PizzaBoxAnHandlerTxtPD(HandlerBase):
+    """Read PizzaBox text files using info from filestore."""
+
+    def __init__(self, fpath):
+        self.df = pd.read_table(fpath, names=['ts_s', 'ts_ns', 'index', 'adc'], sep=' ')
+
+    def __call__(self):
+        return self.df
+
+
+class PizzaBoxDIHandlerTxtPD(HandlerBase):
+    """Read PizzaBox text files using info from filestore."""
+
+    def __init__(self, fpath):
+        self.df = pd.read_table(fpath, names=['ts_s', 'ts_ns', 'encoder', 'index', 'di'], sep=' ')
+
+    def __call__(self):
+        return self.df
+
+
+class PizzaBoxEncHandlerTxtPD(HandlerBase):
+    """Read PizzaBox text files using info from filestore."""
+
+    def __init__(self, fpath):
+        self.df = pd.read_table(fpath, names=['ts_s', 'ts_ns', 'encoder', 'index', 'state'], sep=' ')
+
+    def __call__(self):
+        return self.df

--- a/nsls2_detector_handlers/pizzabox.py
+++ b/nsls2_detector_handlers/pizzabox.py
@@ -1,6 +1,7 @@
+from collections import namedtuple
+
 import pandas as pd
 
-from collections import namedtuple
 from . import HandlerBase
 
 

--- a/nsls2_detector_handlers/srx_flyscans.py
+++ b/nsls2_detector_handlers/srx_flyscans.py
@@ -1,6 +1,6 @@
-from . import HandlerBase
-
 import h5py
+
+from . import HandlerBase
 
 
 class ZebraHDF5Handler(HandlerBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # List required packages in this file, one per line.
 h5py
+numpy
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # List required packages in this file, one per line.
 h5py
+pandas

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
             'PIZZABOX_AN_FILE_TXT_PD = nsls2_detector_handlers.pizzabox:PizzaBoxAnHandlerTxtPD',
             'PIZZABOX_DI_FILE_TXT_PD = nsls2_detector_handlers.pizzabox:PizzaBoxDIHandlerTxtPD',
             'PIZZABOX_ENC_FILE_TXT_PD = nsls2_detector_handlers.pizzabox:PizzaBoxEncHandlerTxtPD',
+            'ELECTROMETER = nsls2_detector_handlers.electrometer:ElectrometerBinFileHandler',
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,12 @@ setup(
         'databroker.handlers': [
             'ZEBRA_HDF51 = nsls2_detector_handlers.srx_flyscans:ZebraHDF5Handler',
             'SIS_HDF51 = nsls2_detector_handlers.srx_flyscans:ZebraHDF5Handler',
+            'PIZZABOX_AN_FILE_TXT = nsls2_detector_handlers.pizzabox:PizzaBoxAnHandlerTxt',
+            'PIZZABOX_DI_FILE_TXT = nsls2_detector_handlers.pizzabox:PizzaBoxDIHandlerTxt',
+            'PIZZABOX_ENC_FILE_TXT = nsls2_detector_handlers.pizzabox:PizzaBoxEncHandlerTxt',
+            'PIZZABOX_AN_FILE_TXT_PD = nsls2_detector_handlers.pizzabox:PizzaBoxAnHandlerTxtPD',
+            'PIZZABOX_DI_FILE_TXT_PD = nsls2_detector_handlers.pizzabox:PizzaBoxDIHandlerTxtPD',
+            'PIZZABOX_ENC_FILE_TXT_PD = nsls2_detector_handlers.pizzabox:PizzaBoxEncHandlerTxtPD',
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
Adds handlers from ISS.

Largely copied directly from ISS profile [here](https://github.com/NSLS-II-ISS/profile_collection/blob/master/startup/10-detectors.py#L753-L839) and [here](https://github.com/NSLS-II-ISS/profile_collection/blob/master/startup/30-electrometer.py#L155-L227)

Some formatting and deleting of dead code, but there should be no functional changes except adding `get_file_list` implementations.

Partially addresses #2 

As discussed with @danielballan, QAS pizzabox handlers will be kept separate rather than merging with these, but that will require database changes to retroactively change the spec IDs.

Not included from ISS are the following:

- [SpectroscopyInterpHandler](https://github.com/NSLS-II-ISS/profile_collection/blob/master/startup/50-insert_analysis.py#L293-L314)
- [HDF5DFWriter](https://github.com/NSLS-II-ISS/profile_collection/blob/1e30f8bffb05caa845164a02d200b9f208a4a7fe/startup/50-insert_analysis.py#L87-L108)
- [HDF5DFHandler](https://github.com/NSLS-II-ISS/profile_collection/blob/1e30f8bffb05caa845164a02d200b9f208a4a7fe/startup/50-insert_analysis.py#L73-L85)

`SpectroscopyInterpHandler` because it is never referenced anywhere else in ISS. This means it also has no apparent spec ID to use for the entrypoint. I'm guessing it must be dead code?

`HDF5DFWriter` is used in non-standard way [here](https://github.com/NSLS-II-ISS/profile_collection/blob/1e30f8bffb05caa845164a02d200b9f208a4a7fe/startup/50-insert_analysis.py#L135-L150) and [here](https://github.com/NSLS-II-ISS/profile_collection/blob/1e30f8bffb05caa845164a02d200b9f208a4a7fe/startup/50-insert_analysis.py#L230-L263). `HDF5DFHandler` appears to be a simplified version of it, used only for testing [here](https://github.com/NSLS-II-ISS/profile_collection/blob/b0fb6e5070e3bf56d454434257c69f63f51a4e44/tests/test_analysis_write.py#L60). I'm not sure these can be extracted? Do we want to try?